### PR TITLE
Replace oracle-1.181 with oracle-8.191

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -73,7 +73,7 @@ get_java() {
 
 	case $distro-$version in
 		oracle-10.0.2) url=$base$version+13/19aef61b38124481863b1413dce1855f/jdk-$version'_'$(get_current_variant $variant) ;;
-		oracle-8.181)  url=$base$oracle8_version-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-$oracle8_version-$variant ;;
+		oracle-8.191)  url=$base$oracle8_version-b12/2787e4a523244c269598db4e85c51e0c/jdk-$oracle8_version-$variant ;;
 		oracle-8.141)  url=$base$oracle8_version-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-$oracle8_version-$variant ;;
 		oracle-8.131)  url=$base$oracle8_version-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-$oracle8_version-$variant ;;
 		openjdk-10.0.2) url=$base$version/19aef61b38124481863b1413dce1855f/13/openjdk-$version'_'$(get_current_variant $variant) ;;

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,3 +1,3 @@
 #!/bin/env bash
 
-echo "oracle-8.131 oracle-8.141 oracle-8.181 oracle-10.0.2 openjdk-10.0.2"
+echo "oracle-8.131 oracle-8.141 oracle-8.191 oracle-10.0.2 openjdk-10.0.2"


### PR DESCRIPTION
8.181 distribution has been removed from the download site and URL now
returns 404.

Closes #36