### PR TITLE
Replace 8.191 with 8.202 and 11.0.1 with 11.0.2

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -114,8 +114,8 @@ get_java() {
 	local oracle8_version=$(echo $version | sed -e 's|\.|u|g')
 
 	case $distro-$version in
-		oracle-11.0.1) url=$base$version+13/90cf5d8f270a4347a95050320eef3fb7/jdk-$version'_'$(get_current_variant $variant) ;;
-		oracle-8.191)  url=$base$oracle8_version-b12/2787e4a523244c269598db4e85c51e0c/jdk-$oracle8_version-$variant ;;
+		oracle-11.0.2) url=$base$version+9/f51449fcd52f4d52b93a989c5c56ed3c/jdk-$version'_'$(get_current_variant $variant) ;;
+		oracle-8.202)  url=$base$oracle8_version-b08/1961070e4c9b4e26a04e7f5a083f551e/jdk-$oracle8_version-$variant ;;
 		oracle-8.141)  url=$base$oracle8_version-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-$oracle8_version-$variant ;;
 		oracle-8.131)  url=$base$oracle8_version-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-$oracle8_version-$variant ;;
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,8 +3,8 @@
 echo $(echo "
 oracle-8.131
 oracle-8.141
-oracle-8.191
-oracle-11.0.1
+oracle-8.202
+oracle-11.0.2
 openjdk-10.0.2
 openjdk-11
 openjdk-11.0.1


### PR DESCRIPTION
8.191 and 11.0.1 give me similar errors:

```bash
$ asdf install java oracle-8.191
░asdf java :)░ downloading http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.tar.gz
####################################################################################################################################################### 100.0% -=#=- #     #       #                                                                                                                                       
curl: (22) The requested URL returned error: 404 Not Found
░asdf java :(░ asdf java failed. downloading java dist
```

Versions 8.202 and 11.0.2 work without a problem
```bash
$ asdf install java oracle-8.202
░asdf java :)░ downloading http://download.oracle.com/otn-pub/java/jdk/8u202-b08/1961070e4c9b4e26a04e7f5a083f551e/jdk-8u202-linux-x64.tar.gz
####################################################################################################################################################### 100.0%####################################################################################################################################################### 100.0%
░asdf java :)░ expanding java dist
░asdf java :)░ oracle-8.202 was installed successfully
```