### PR TITLE
Add legacy filename support for jenv

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,1 @@
+echo ".java-version"


### PR DESCRIPTION
`jenv` manages Java versions and uses a `.java-version` file for that.
This adds support for the old filename from `jenv`.