### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ asdf global java openjdk-11.0.1
 If you want or need `JAVA_HOME` set you can load our `asdf` wrapper to your shell initialization (in `.bashrc`, for example):
 
 ```bash
-. ~/.asdf/plugins/java/asdf-java-wrapper.bash
+. ~/.asdf/plugins/java/set-java-home.bash
 ```
 
 Or in `.zshrc`
 
 ```zsh
-. ~/.asdf/plugins/java/asdf-java-wrapper.zsh
+. ~/.asdf/plugins/java/set-java-home.zsh
 ```
 
 If you need to disable colors, try:


### PR DESCRIPTION
Fixes path to `set-java-home` for newest version.